### PR TITLE
Store full message objects in IPFS and sync hashes only

### DIFF
--- a/src/biome.js
+++ b/src/biome.js
@@ -82,9 +82,10 @@ class Biome extends EventEmitter {
             )
         })
 
-        /*
-        this._events.shared.on('change', (change) => {
-            const added = change.add
+        this._events.shared.on('change', async (change) => {
+            const addedPath = change.add
+            const added = await this._readIpfs(addedPath)
+
             switch(added.type) {
                 case 'link':
                 case 'seed':
@@ -93,7 +94,6 @@ class Biome extends EventEmitter {
             }
             this.emit('new event', added)
         })
-        */
 
         this._started = true
     }
@@ -120,13 +120,6 @@ class Biome extends EventEmitter {
         } else {
             return this._eventsChrono.filter(e => e.type === type)
         }
-
-        /*
-        return [ {
-            ts: Date.now() / 1000,
-            type: 'seed',
-            msg: "zb2rhZp3WapJaG6DQizqEP3SruMVScn35vixhgGMAyarNYoae" } ]
-        */
     }
 
     async addEvent({from, type, msg}) {


### PR DESCRIPTION
the g-set CRDT wasn't merging our sets of messages correctly because deep object comparison isn't done by `Set`

this moves the whole message object to IPFS and synchronizes identifiers only 

notes:
- serializing to JSON obviously not ideal, should define an IPLD schema?
- could also patch g-set for deep comparisons but this is a more user-space solution (and reduces the size of the in-memory shared log)
- needs lots of error handling!!!